### PR TITLE
Fix UsersController response and improve client auth flow to create missing users

### DIFF
--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -4,7 +4,6 @@ class V1::UsersController < ApplicationController
 
     user = User.find_by(uid: params[:uid])
     return render json: { error: "user not found" }, status: :not_found unless user
-    end
 
     todos = user.todos.order(sort: "ASC")
     render json: { user: user, todos: todos }

--- a/frontend/plugins/auth-check.js
+++ b/frontend/plugins/auth-check.js
@@ -3,21 +3,42 @@ import axios from "@/plugins/axios"
 
 const authCheck = ({ store }) => {
   firebase.auth().onAuthStateChanged(async user => {
-    if (user) {
-      try {
-        const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
-        if (data && data.user) {
-          store.commit("setUser", data)
-          return
-        }
-      } catch (error) {
-        if (!error.response || error.response.status !== 404) {
-          console.log(error)
-        }
+    if (!user) {
+      store.commit("setUser", null)
+      return
+    }
+
+    try {
+      const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
+      if (data && data.user) {
+        store.commit("setUser", data)
+      }
+      return
+    } catch (error) {
+      if (!error.response || error.response.status !== 404) {
+        console.log(error)
+        store.commit("setUser", null)
+        return
       }
     }
 
-    store.commit("setUser", null)
+    try {
+      const { data: createdUser } = await axios.post("/v1/users", {
+        user: {
+          email: user.email,
+          uid: user.uid,
+          name: user.displayName || "ゲスト"
+        }
+      })
+      store.commit("setUser", {
+        user: createdUser,
+        todos: [],
+        rewards: []
+      })
+    } catch (error) {
+      console.log(error)
+      store.commit("setUser", null)
+    }
   })
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the API returns a user's todos and full payload from `V1::UsersController#index` by fixing a misplaced control flow termination. 
- Make the frontend authentication handler robust by clearing state on sign-out, fetching existing users, and creating a new user on first sign-in (HTTP 404). 

### Description
- Removed an extraneous `end` in `backend/app/controllers/v1/users_controller.rb` so `todos = user.todos.order(sort: "ASC")` runs and the controller returns `{ user, todos }` as intended. 
- Rewrote `frontend/plugins/auth-check.js` to immediately clear the store when `user` is `null`, fetch the user via `GET /v1/users?uid=...`, and commit the returned data when present. 
- Added logic to `auth-check` to create a missing user via `POST /v1/users` (sending `email`, `uid`, and `name` with a default `user.displayName || "ゲスト"`) and commit the created user with empty `todos` and `rewards`. 
- Improved error handling in `auth-check` to log unexpected errors and clear the store on failure. 

### Testing
- Ran the backend test suite with `bundle exec rspec` and all specs passed. 
- Ran the frontend tests and linters with `yarn test` and `yarn lint` and they completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a265fdd63c8330ab8bb44027026bbb)