### PR TITLE
Fix user auth/load flow, cleanup watcher lifecycle, and remove stray `end` in UsersController

### DIFF
--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -4,7 +4,6 @@ class V1::UsersController < ApplicationController
 
     user = User.find_by(uid: params[:uid])
     return render json: { error: "user not found" }, status: :not_found unless user
-    end
 
     todos = user.todos.order(sort: "ASC")
     render json: { user: user, todos: todos }

--- a/frontend/pages/user.vue
+++ b/frontend/pages/user.vue
@@ -36,18 +36,25 @@ export default {
       show1: false,
       show2: false,
       error: "",
-      showContent: false
+      showContent: false,
+      unwatchCurrentUser: null
     };
   },
-  fetch({ store, redirect }) {
-    store.watch(
+  created() {
+    this.unwatchCurrentUser = this.$store.watch(
       state => state.currentUser,
-      (newUser, oldUser) => {
+      newUser => {
         if (!newUser) {
-          return redirect("/login");
+          this.$router.replace("/login");
         }
-      }
+      },
+      { immediate: true }
     );
+  },
+  beforeDestroy() {
+    if (this.unwatchCurrentUser) {
+      this.unwatchCurrentUser();
+    }
   },
   components: {
     AddTodo,

--- a/frontend/plugins/auth-check.js
+++ b/frontend/plugins/auth-check.js
@@ -3,21 +3,58 @@ import axios from "@/plugins/axios"
 
 const authCheck = ({ store }) => {
   firebase.auth().onAuthStateChanged(async user => {
-    if (user) {
-      try {
-        const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
-        if (data && data.user) {
-          store.commit("setUser", data)
+    if (!user) {
+      store.commit("setUser", null)
+      return
+    }
+
+    try {
+      const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
+      if (data && data.user) {
+        store.commit("setUser", data)
+      }
+      return
+    } catch (error) {
+      if (!error.response || error.response.status !== 404) {
+        console.log(error)
+        const currentUser = store.state.currentUser
+        if (currentUser && currentUser.user) {
           return
         }
-      } catch (error) {
-        if (!error.response || error.response.status !== 404) {
-          console.log(error)
-        }
+
+        store.commit("setUser", {
+          user: {
+            email: user.email,
+            name: user.displayName || "ゲスト",
+            uid: user.uid
+          },
+          todos: [],
+          rewards: []
+        })
+        return
       }
     }
 
-    store.commit("setUser", null)
+    try {
+      const { data: createdUser } = await axios.post("/v1/users", {
+        user: {
+          email: user.email,
+          uid: user.uid,
+          name: user.displayName || "ゲスト"
+        }
+      })
+      store.commit("setUser", {
+        user: createdUser,
+        todos: [],
+        rewards: []
+      })
+    } catch (error) {
+      console.log(error)
+      const currentUser = store.state.currentUser
+      if (!currentUser || !currentUser.user) {
+        store.commit("setUser", null)
+      }
+    }
   })
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the frontend properly reacts to Firebase auth changes, creates or loads the corresponding backend user, and avoids navigation/race issues by watching the store instead of using `fetch`, while also fixing a Ruby controller syntax bug that would break user requests.

### Description
- Remove a stray `end` in `V1::UsersController` so user lookup and todo rendering execute correctly. 
- Replace the page-level `fetch` store check with a `created()` `this.$store.watch` in `frontend/pages/user.vue`, use `this.$router.replace('/login')` for redirects, and add `unwatchCurrentUser` with a `beforeDestroy()` cleanup to avoid leaked watchers. 
- Update `frontend/plugins/auth-check.js` to handle signed-out users immediately, attempt to `GET /v1/users?uid=...`, fall back to creating a user with `POST /v1/users` if missing, and set a sensible guest user object on error to keep the UI stable. 
- Improve error handling and state commits so the store is consistently set to either the fetched/created user or `null` when appropriate. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a265fdd63c8330ab8bb44027026bbb)