### PR TITLE
Fix users controller syntax and improve auth/user handling on frontend

### DIFF
--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -4,7 +4,6 @@ class V1::UsersController < ApplicationController
 
     user = User.find_by(uid: params[:uid])
     return render json: { error: "user not found" }, status: :not_found unless user
-    end
 
     todos = user.todos.order(sort: "ASC")
     render json: { user: user, todos: todos }

--- a/frontend/pages/user.vue
+++ b/frontend/pages/user.vue
@@ -23,7 +23,6 @@ import AddTodo from "@/components/AddTodo";
 import TodoList from "@/components/TodoList";
 import Status from "@/components/Status";
 import axios from "@/plugins/axios";
-import firebase from "@/plugins/firebase";
 
 export default {
   data() {
@@ -39,15 +38,15 @@ export default {
       showContent: false
     };
   },
-  fetch({ store, redirect }) {
-    store.watch(
-      state => state.currentUser,
-      (newUser, oldUser) => {
+  watch: {
+    currentUser: {
+      immediate: true,
+      handler(newUser) {
         if (!newUser) {
-          return redirect("/login");
+          this.$router.replace("/login");
         }
       }
-    );
+    }
   },
   components: {
     AddTodo,

--- a/frontend/plugins/auth-check.js
+++ b/frontend/plugins/auth-check.js
@@ -3,21 +3,58 @@ import axios from "@/plugins/axios"
 
 const authCheck = ({ store }) => {
   firebase.auth().onAuthStateChanged(async user => {
-    if (user) {
-      try {
-        const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
-        if (data && data.user) {
-          store.commit("setUser", data)
+    if (!user) {
+      store.commit("setUser", null)
+      return
+    }
+
+    try {
+      const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
+      if (data && data.user) {
+        store.commit("setUser", data)
+      }
+      return
+    } catch (error) {
+      if (!error.response || error.response.status !== 404) {
+        console.log(error)
+        const currentUser = store.state.currentUser
+        if (currentUser && currentUser.user) {
           return
         }
-      } catch (error) {
-        if (!error.response || error.response.status !== 404) {
-          console.log(error)
-        }
+
+        store.commit("setUser", {
+          user: {
+            email: user.email,
+            name: user.displayName || "ゲスト",
+            uid: user.uid
+          },
+          todos: [],
+          rewards: []
+        })
+        return
       }
     }
 
-    store.commit("setUser", null)
+    try {
+      const { data: createdUser } = await axios.post("/v1/users", {
+        user: {
+          email: user.email,
+          uid: user.uid,
+          name: user.displayName || "ゲスト"
+        }
+      })
+      store.commit("setUser", {
+        user: createdUser,
+        todos: [],
+        rewards: []
+      })
+    } catch (error) {
+      console.log(error)
+      const currentUser = store.state.currentUser
+      if (!currentUser || !currentUser.user) {
+        store.commit("setUser", null)
+      }
+    }
   })
 }
 


### PR DESCRIPTION
### Motivation

- Fix a syntax error in the users controller that could break the users endpoint and streamline the client-side handling of authentication state. 
- Make authentication handling more resilient by handling signed-out state immediately and providing a fallback user representation when remote user lookup fails. 
- Improve navigation behavior on the user page when no authenticated user is present.

### Description

- Remove an extraneous `end` in `backend/app/controllers/v1/users_controller.rb` to correct the controller method structure. 
- Replace the custom `fetch`/`store.watch` logic in `frontend/pages/user.vue` with a Vue `watch` on `currentUser` that uses `this.$router.replace("/login")` and remove an unused `firebase` import. 
- Rework `frontend/plugins/auth-check.js` to immediately set `null` in the store when there is no Firebase user, perform a `GET /v1/users?uid=...` lookup when a user exists, and fall back to a local guest-like user object if lookup fails with non-404 errors. 
- Add logic to create a remote user via `POST /v1/users` when needed and set the store with `user`, `todos`, and `rewards` structures; include error handling that preserves an existing store user or clears it when creation fails.

### Testing

- Ran the backend test suite with `bundle exec rspec` and the suite completed successfully. 
- Ran frontend checks with `npm run lint` and `npm run test` and there were no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a265fdd63c8330ab8bb44027026bbb)