### PR TITLE
Fix user lookup and auth flow; add AddTodo validation and frontend watcher updates

### DIFF
--- a/backend/app/controllers/v1/users_controller.rb
+++ b/backend/app/controllers/v1/users_controller.rb
@@ -4,7 +4,6 @@ class V1::UsersController < ApplicationController
 
     user = User.find_by(uid: params[:uid])
     return render json: { error: "user not found" }, status: :not_found unless user
-    end
 
     todos = user.todos.order(sort: "ASC")
     render json: { user: user, todos: todos }

--- a/frontend/components/AddTodo.vue
+++ b/frontend/components/AddTodo.vue
@@ -40,19 +40,23 @@ export default {
     return {
       items: numberRange,
       title: "",
-      point: ""
+      point: 1
     };
   },
   methods: {
     handleSubmit() {
+      if (!this.title || !this.title.trim()) {
+        this.$store.commit("setError", ["やるべきことを入力してください"]);
+        return;
+      }
+
       const todo = {
-        title: this.title,
+        title: this.title.trim(),
         user_id: this.$store.state.currentUser.user.id,
-        point: this.point
+        point: Number(this.point)
       };
       this.$emit("submit", todo);
       this.title = "";
-      this.point = "";
     }
   }
 };

--- a/frontend/components/Status.vue
+++ b/frontend/components/Status.vue
@@ -39,16 +39,6 @@ export default {
       fullIcon: 'mdi-heart',
     };
   },
-  fetch({ store, redirect }) {
-    store.watch(
-      state => state.currentUser,
-      (newUser, oldUser) => {
-        if (!newUser) {
-          return redirect("/login");
-        }
-      }
-    );
-  },
   computed: {
     currentUser() {
       return this.$store.state.currentUser;

--- a/frontend/pages/user.vue
+++ b/frontend/pages/user.vue
@@ -23,7 +23,6 @@ import AddTodo from "@/components/AddTodo";
 import TodoList from "@/components/TodoList";
 import Status from "@/components/Status";
 import axios from "@/plugins/axios";
-import firebase from "@/plugins/firebase";
 
 export default {
   data() {
@@ -39,15 +38,15 @@ export default {
       showContent: false
     };
   },
-  fetch({ store, redirect }) {
-    store.watch(
-      state => state.currentUser,
-      (newUser, oldUser) => {
+  watch: {
+    currentUser: {
+      immediate: true,
+      handler(newUser) {
         if (!newUser) {
-          return redirect("/login");
+          this.$router.replace("/login");
         }
       }
-    );
+    }
   },
   components: {
     AddTodo,

--- a/frontend/plugins/auth-check.js
+++ b/frontend/plugins/auth-check.js
@@ -3,21 +3,58 @@ import axios from "@/plugins/axios"
 
 const authCheck = ({ store }) => {
   firebase.auth().onAuthStateChanged(async user => {
-    if (user) {
-      try {
-        const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
-        if (data && data.user) {
-          store.commit("setUser", data)
+    if (!user) {
+      store.commit("setUser", null)
+      return
+    }
+
+    try {
+      const { data } = await axios.get(`/v1/users?uid=${user.uid}`)
+      if (data && data.user) {
+        store.commit("setUser", data)
+      }
+      return
+    } catch (error) {
+      if (!error.response || error.response.status !== 404) {
+        console.log(error)
+        const currentUser = store.state.currentUser
+        if (currentUser && currentUser.user) {
           return
         }
-      } catch (error) {
-        if (!error.response || error.response.status !== 404) {
-          console.log(error)
-        }
+
+        store.commit("setUser", {
+          user: {
+            email: user.email,
+            name: user.displayName || "ゲスト",
+            uid: user.uid
+          },
+          todos: [],
+          rewards: []
+        })
+        return
       }
     }
 
-    store.commit("setUser", null)
+    try {
+      const { data: createdUser } = await axios.post("/v1/users", {
+        user: {
+          email: user.email,
+          uid: user.uid,
+          name: user.displayName || "ゲスト"
+        }
+      })
+      store.commit("setUser", {
+        user: createdUser,
+        todos: [],
+        rewards: []
+      })
+    } catch (error) {
+      console.log(error)
+      const currentUser = store.state.currentUser
+      if (!currentUser || !currentUser.user) {
+        store.commit("setUser", null)
+      }
+    }
   })
 }
 


### PR DESCRIPTION
### Motivation

- Fix a controller logic bug that prevented returning a user's todos and improve stability of the auth lifecycle.
- Prevent invalid todo submissions and provide sane defaults for todo creation.
- Replace server-side page fetch watchers with client-side reactive watchers to better suit SPA navigation.
- Harden the authentication plugin to fetch/create users reliably and handle error cases.

### Description

- Remove an extraneous `end` in `V1::UsersController#index` so the controller correctly finds a user and returns `todos` (file: `backend/app/controllers/v1/users_controller.rb`).
- Improve `AddTodo.vue` by setting `point` default to `1`, trimming and validating `title`, converting `point` to `Number`, emitting the new todo, and preventing empty submissions (file: `frontend/components/AddTodo.vue`).
- Remove the `fetch` store watcher from `Status.vue` to eliminate server-side fetch-based redirection (file: `frontend/components/Status.vue`).
- Replace the page-level `fetch` watcher in `user.vue` with a component `watch` on `currentUser` that uses `this.$router.replace('/login')` for navigation, and clean up unused imports (file: `frontend/pages/user.vue`).
- Refactor `auth-check.js` to handle `onAuthStateChanged` more robustly by clearing the store on sign-out, attempting to GET the user, creating the user via POST when missing, and providing fallbacks on error while ensuring the store shape (`user`, `todos`, `rewards`) is set consistently (file: `frontend/plugins/auth-check.js`).

### Testing

- No automated tests were executed for these changes.
- Manual local validation performed during development to verify navigation and basic todo submission flows (not an automated test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a265fdd63c8330ab8bb44027026bbb)